### PR TITLE
Remove branch name on test image name

### DIFF
--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -15,7 +15,7 @@ def call(Map args) {
   def days_to_keep = 10
   def num_to_keep = 10
 
-  def testImage = { distribution -> docker_registry + ':tailor-image-' + distribution + '-test-image-master' }
+  def testImage = { distribution -> docker_registry + ':tailor-image-' + distribution + '-test-image' }
 
   pipeline {
     agent none


### PR DESCRIPTION
Since this commit (https://github.com/locusrobotics/tailor-image/commit/4a84fbed54d223d66061b2da6e2b0056dda41569) we're not using the branch name on the test image name. 

But since the last change to allow running with bionic, the tests started failing (http://tailor.locusbots.io/blue/organizations/jenkins/repos%2Flocus_bots/detail/devel/123/pipeline/36). For some reason, the previous tests weren't failing and those were pulling the correct image (http://tailor.locusbots.io/blue/organizations/jenkins/repos%2Flocus_bots/detail/devel/122/pipeline). This should fix that issue.