### PR TITLE
Add cloudfront distribution id to the recipe

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,8 +143,8 @@ pipeline {
       agent any
       steps {
         script {
+          unstash(name: 'rosdistro')
           common_config = readYaml(file: recipes_yaml)['common']
-
           def distribution_id = common_config.find{ it.key == "cloudfront_distribution_id" }?.value
 
           if(distribution_id) {


### PR DESCRIPTION
Add cache invalidation for Cloudfront using optional parameter. See also https://github.com/locusrobotics/rosdistro/pull/22