### PR TITLE
Use build_label as the top level dir

### DIFF
--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -157,7 +157,7 @@ def call(Map args) {
                 s3Upload(
                   // TODO(pbovbel) should go 'all in' on s3 with tailor? Silly to post-process everywhere.
                   bucket: common_config['apt_repo'] - 's3://',
-                  path: getBuildTrack(),
+                  path: getBuildLabel(),
                   includePathPattern: 'rosdistro/**, rosdep/**, config/**',
                   workingDir: 'rosdistro',
                 )


### PR DESCRIPTION
The build process is still uploading the artifacts to the release_track dir, this fixes it to use the release_label instead