### PR TITLE
Use timestamp from parameters

### DIFF
--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -12,6 +12,7 @@ def call(Map args) {
   String tailor_image = args['versions'].get('tailor_image')
   String tailor_meta = args['versions'].get('tailor_meta')
 
+  def timestamp = new Date().format('yyyyMMdd.HHmmss')
   def recipes_yaml = 'rosdistro/config/recipes.yaml'
   def common_config = [:]
 
@@ -95,6 +96,7 @@ def call(Map args) {
       string(name: 'apt_repo', value: common_config['apt_repo']),
       string(name: 'docker_registry', value: common_config['docker_registry']),
       string(name: 'tailor_meta', value: tailor_meta),
+      string(name: 'timestamp', value: timestamp),
       booleanParam(name: 'force_mirror', value: params.force_mirror),
       booleanParam(name: 'deploy', value: true),
     ]
@@ -157,7 +159,7 @@ def call(Map args) {
                 s3Upload(
                   // TODO(pbovbel) should go 'all in' on s3 with tailor? Silly to post-process everywhere.
                   bucket: common_config['apt_repo'] - 's3://',
-                  path: getBuildTrack(),
+                  path: getBuildLabel(),
                   includePathPattern: 'rosdistro/**, rosdep/**, config/**',
                   workingDir: 'rosdistro',
                 )


### PR DESCRIPTION
Use a single timestamp for all the different pipelines. I've tested this on toydistro http://tailor.locusbots.io/blue/organizations/jenkins/ci%2Ftoydistro/detail/master/656/pipeline