### PR TITLE
update branch protection to require code owner reviews

### DIFF
--- a/tailor_meta/update_repo_settings.py
+++ b/tailor_meta/update_repo_settings.py
@@ -55,7 +55,9 @@ def update_repo_settings(rosdistro_index: pathlib.Path, recipes: Mapping[str, An
             # Protect branch
             branch = gh_repo.get_branch(repository_data.get_data()["source"]["version"])
             if deploy:
-                branch.edit_protection(strict=True, required_approving_review_count=1)
+                branch.edit_protection(strict=True,
+                                       required_approving_review_count=1,
+                                       require_code_owner_reviews=True)
 
             # Create label
             if deploy:


### PR DESCRIPTION
LOW PRIORITY!!

@garyservin brought up on https://github.com/locusrobotics/locus_navigation/pull/337 that tailor-meta might overwrite branch protections. This pr makes sure that the branch protections are updated to require a code owner review. If a repo does not have a CODEOWNER file the branch protection will be ignored.

I don't have a great way to test this change so if some one else can test it or has a good way to test it that would be great. 
-Josh