### PR TITLE
Have Tailor-Meta use a diff mirror

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 LABEL tailor="environment"
 
@@ -13,6 +13,7 @@ ENV AWS_SECRET_ACCESS_KEY ${AWS_SECRET_ACCESS_KEY}
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 
+RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2.&/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install --no-install-recommends -y locales curl gnupg1 gpgv1 sudo
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
This PR is to have tailor-meta use a different mirror. This branch has been used by the buildfarm for the past week, and things seem to be running okay. This is to make things official. 