### PR TITLE
Retain "feature" in build label

### DIFF
--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -53,7 +53,7 @@ def call(Map args) {
       case BuildType.HOTDOG:
         return getBuildTrack()
       case BuildType.FEATURE:
-        return env.BRANCH_NAME - 'feature/'
+        return env.BRANCH_NAME.replaceFirst("feature/", "feature-")
       case BuildType.TRIVIAL:
         return null
     }


### PR DESCRIPTION
To comply with version semantics with FV/FA keep the "feature" portion of the branch name so its treated similarly to hotdog. This lets devs create any branch name, and it will just be prefixed by "feature-" thereby allowing it to be loaded onto a floor if needed.