### PR TITLE
Use Docker cache while still refreshing apt packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,8 @@ pipeline {
               parent_image = docker.build(parent_image_label,
                 "-f tailor-meta/environment/Dockerfile --cache-from ${parent_image_label} " +
                 "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
-                "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY .")
+                "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
+                "--build-arg BUILDKIT_INLINE_CACHE=1 .")
             }
             parent_image.inside() {
               sh('pip3 install -e tailor-meta')

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -12,6 +12,7 @@ ENV AWS_SECRET_ACCESS_KEY ${AWS_SECRET_ACCESS_KEY}
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
+ARG APT_REFRESH_KEY
 
 RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2.&/g' /etc/apt/sources.list
 RUN echo "APT refresh key=${APT_REFRESH_KEY}"

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -14,6 +14,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 
 RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2.&/g' /etc/apt/sources.list
+RUN echo "APT refresh key=${APT_REFRESH_KEY}"
 RUN apt-get update && apt-get install --no-install-recommends -y locales curl gnupg1 gpgv1 sudo
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -84,6 +84,12 @@ def call(Map args) {
     }
   }
 
+  def weekNum = sh(
+    script: 'date -u +%G-W%V',
+    returnStdout: true,
+    label: 'Get week number'
+  ).trim()
+
   // (pbovbel) Currently all sub-pipelines use the same parameters, even if some of them are unused.
   // This may need to change in the future.
   def createJobParameters = {
@@ -101,6 +107,7 @@ def call(Map args) {
       booleanParam(name: 'force_mirror', value: params.force_mirror),
       booleanParam(name: 'deploy', value: true),
       booleanParam(name: 'invalidate_cache', value: params.invalidate_cache),
+      string(name: 'apt_refresh_key', value: weekNum)
     ]
   }
 

--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -100,6 +100,7 @@ def call(Map args) {
       string(name: 'python_version', value: common_config['python_version']),
       booleanParam(name: 'force_mirror', value: params.force_mirror),
       booleanParam(name: 'deploy', value: true),
+      booleanParam(name: 'invalidate_cache', value: params.invalidate_cache),
     ]
   }
 
@@ -116,6 +117,7 @@ def call(Map args) {
 
     parameters {
       booleanParam(name: 'force_mirror', defaultValue: false)
+      booleanParam(name: 'invalidate_cache', defaultValue: false)
     }
 
     options {

--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -84,11 +84,9 @@ def call(Map args) {
     }
   }
 
-  def weekNum = sh(
-    script: 'date -u +%G-W%V',
-    returnStdout: true,
-    label: 'Get week number'
-  ).trim()
+  def cal = Calendar.getInstance(TimeZone.getTimeZone('UTC'))
+  cal.setTime(new Date())
+  def weekNum = String.format("%d-W%02d", cal.get(Calendar.YEAR), cal.get(Calendar.WEEK_OF_YEAR))
 
   // (pbovbel) Currently all sub-pipelines use the same parameters, even if some of them are unused.
   // This may need to change in the future.


### PR DESCRIPTION
The current flag `--cache-from` given to the docker build command is not working. If we want to re-use previous docker images that we already have build when no change is made inside the dockerfile, then this PR makes that happen. When using the cache with Dockers, we need a balance between speed and working with stale apt packages. Thus, this PR tries to prevent having very old packages by invalidating the cache once a week. Moreover, it exposes a new parameter to invalidate the cache manually if required. 

This PR does the following: 
* makes use of Docker cache when re-building the Docker images
* exposes a new parameter named `invalidate_cache` to manually trigger the cache invalidation when needed
* uses a parameter named `apt_refresh_key` which is set to a combination of year and week number to trigger the cache invalidation once per week. This way the apt packages get updated at least once per week and we do not risk missing important updates. 