### PR TITLE
Handle concurrent integration tests and build-and-test runs 

### DIFF
--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -73,8 +73,6 @@ def call(Map args) {
             cancelPreviousBuilds()
 
             // Only build master or release branches automatically, feature branches require SCM or manual trigger.
-            echo('source_branch: ' + source_branch)
-            echo('current branch: ' + env.BRANCH_NAME)
             if (env.BRANCH_NAME == source_branch) {
               triggers.add(upstream(upstreamProjects: "$rosdistro_job", threshold: hudson.model.Result.SUCCESS))
             }
@@ -132,7 +130,7 @@ def call(Map args) {
                         python3 /home/locus/pull_rosdistro.py --src-dir rosdistro --github-key $GITHUB_TOKEN --clean --ref $release_track
                         echo "Pulling distro repositories..."
                         python3 /home/locus/pull_distro_repositories.py --src-dir workspace/src --github-key $GITHUB_TOKEN \
-                          --recipes $recipes_yaml --rosdistro-index $rosdistro_index --clean --ref ${CHANGE_NAME} --rosdistro-name $rosdistro_name
+                          --recipes $recipes_yaml --rosdistro-index $rosdistro_index --clean --ref ${env.CHANGE_BRANCH} --rosdistro-name $rosdistro_name
 
                         rosdep check --from-paths workspace/src/$rosdistro_name --ignore-src
                       """)

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -20,7 +20,7 @@ def call(Map args) {
 
   def testImage = { distribution -> docker_registry - "https://" + ':tailor-image-test-' + distribution + '-' + release_label }
   def dependencyImage = { distribution -> docker_registry - "https://" + ':tailor-image-dep-checker-' + distribution + '-' + release_label }
-  def integration_tests_branch = 'handle-pipeline-error'
+  def integration_tests_branch = 'main'
   def pr_comment_cause = 'com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause'
 
   pipeline {

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -156,7 +156,7 @@ def call(Map args) {
         when {
           expression {
             !currentBuild.getBuildCauses(pr_comment_cause) &&
-            currentBuild.result == null
+            currentBuild.result != 'ABORTED'
           }
         }
         steps {

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -130,7 +130,7 @@ def call(Map args) {
                         python3 /home/locus/pull_rosdistro.py --src-dir rosdistro --github-key $GITHUB_TOKEN --clean --ref $release_track
                         echo "Pulling distro repositories..."
                         python3 /home/locus/pull_distro_repositories.py --src-dir workspace/src --github-key $GITHUB_TOKEN \
-                          --recipes $recipes_yaml --rosdistro-index $rosdistro_index --clean --ref ${env.CHANGE_BRANCH} --rosdistro-name $rosdistro_name
+                          --recipes $recipes_yaml --rosdistro-index $rosdistro_index --clean --ref ${env.CHANGE_BRANCH ?: env.BRANCH_NAME} --rosdistro-name $rosdistro_name
 
                         rosdep check --from-paths workspace/src/$rosdistro_name --ignore-src
                       """)

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -20,7 +20,7 @@ def call(Map args) {
 
   def testImage = { distribution -> docker_registry - "https://" + ':tailor-image-test-' + distribution + '-' + release_label }
   def dependencyImage = { distribution -> docker_registry - "https://" + ':tailor-image-dep-checker-' + distribution + '-' + release_label }
-  def integration_tests_branch = 'main'
+  def integration_tests_branch = 'handle-pipeline-error'
   def pr_comment_cause = 'com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause'
 
   pipeline {

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -73,6 +73,8 @@ def call(Map args) {
             cancelPreviousBuilds()
 
             // Only build master or release branches automatically, feature branches require SCM or manual trigger.
+            echo('source_branch: ' + source_branch)
+            echo('current branch: ' + env.BRANCH_NAME)
             if (env.BRANCH_NAME == source_branch) {
               triggers.add(upstream(upstreamProjects: "$rosdistro_job", threshold: hudson.model.Result.SUCCESS))
             }
@@ -130,7 +132,7 @@ def call(Map args) {
                         python3 /home/locus/pull_rosdistro.py --src-dir rosdistro --github-key $GITHUB_TOKEN --clean --ref $release_track
                         echo "Pulling distro repositories..."
                         python3 /home/locus/pull_distro_repositories.py --src-dir workspace/src --github-key $GITHUB_TOKEN \
-                          --recipes $recipes_yaml --rosdistro-index $rosdistro_index --clean --ref ${BRANCH_NAME} --rosdistro-name $rosdistro_name
+                          --recipes $recipes_yaml --rosdistro-index $rosdistro_index --clean --ref ${CHANGE_NAME} --rosdistro-name $rosdistro_name
 
                         rosdep check --from-paths workspace/src/$rosdistro_name --ignore-src
                       """)

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -155,8 +155,7 @@ def call(Map args) {
         agent none
         when {
           expression {
-            !currentBuild.getBuildCauses(pr_comment_cause) &&
-            currentBuild.result != 'ABORTED'
+            !currentBuild.getBuildCauses(pr_comment_cause)
           }
         }
         steps {

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -154,14 +154,13 @@ def call(Map args) {
       stage("Build and test") {
         agent none
         when {
-          expression { !currentBuild.getBuildCauses(pr_comment_cause) }
+          expression {
+            !currentBuild.getBuildCauses(pr_comment_cause) &&
+            currentBuild.result == null
+          }
         }
         steps {
           script {
-            if (currentBuild.result == 'ABORTED') {
-              echo "Build was cancelled, skipping Build and test stage"
-              return
-            }
             def jobs = distributions.collectEntries { distribution ->
               [distribution, { node {
                 try {

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -21,6 +21,7 @@ def call(Map args) {
   def testImage = { distribution -> docker_registry - "https://" + ':tailor-image-test-' + distribution + '-' + release_label }
   def dependencyImage = { distribution -> docker_registry - "https://" + ':tailor-image-dep-checker-' + distribution + '-' + release_label }
   def integration_tests_branch = 'main'
+  def pr_comment_cause = 'com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause'
 
   pipeline {
     agent none
@@ -37,7 +38,13 @@ def call(Map args) {
             sh 'env'
             def triggers = []
             library("tailor-meta@$tailor_meta")
-            cancelPreviousBuilds()
+
+            // Cancel previous builds only if the build was not triggered by a PR comment. This avoids cancelling a
+            // build-and-test run when an integration test is triggered.
+            def build_causes = currentBuild.getBuildCauses(pr_comment_cause)
+            if (build_causes.isEmpty()) {
+              cancelPreviousBuilds()
+            }
 
             // Only build master or release branches automatically, feature branches require SCM or manual trigger.
             if (env.BRANCH_NAME == source_branch) {
@@ -61,7 +68,6 @@ def call(Map args) {
             env.NOTIFICATION_REPO = parts[1]
             env.SHA = env.GIT_COMMIT
 
-            def build_causes = currentBuild.getBuildCauses("com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause")
             if (build_causes.isEmpty()) {
               githubNotify(
                 credentialsId: 'tailor_github_keypass',
@@ -81,7 +87,7 @@ def call(Map args) {
       stage("Trigger PR integration tests"){
         agent none
         when {
-          expression { currentBuild.getBuildCauses("com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause") }
+          expression { currentBuild.getBuildCauses(pr_comment_cause) }
         }
         steps{
           script{
@@ -89,7 +95,7 @@ def call(Map args) {
               def repository = checkout(scm)
               def sha = repository.GIT_COMMIT
 
-              def comment_trigger = currentBuild.getBuildCauses("com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause")
+              def comment_trigger = currentBuild.getBuildCauses(pr_comment_cause)
               def comment_body = (comment_trigger && comment_trigger.size() > 0) ? (comment_trigger[0].commentBody ?: "") : ""
 
               build job: "ci_integration_tests/$integration_tests_branch",
@@ -110,7 +116,7 @@ def call(Map args) {
       stage("Rosdep check") {
         agent none
         when {
-          expression { !currentBuild.getBuildCauses("com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause") }
+          expression { !currentBuild.getBuildCauses(pr_comment_cause) }
         }
         steps {
           script {
@@ -153,7 +159,7 @@ def call(Map args) {
       stage("Build and test") {
         agent none
         when {
-          expression { !currentBuild.getBuildCauses("com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause") }
+          expression { !currentBuild.getBuildCauses(pr_comment_cause) }
         }
         steps {
           script {
@@ -212,7 +218,7 @@ def call(Map args) {
     post{
       always{
         script{
-          def build_causes = currentBuild.getBuildCauses("com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause")
+          def build_causes = currentBuild.getBuildCauses(pr_comment_cause)
           if (build_causes.isEmpty()) {
             def result = currentBuild.currentResult
             switch (result) {

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -31,59 +31,6 @@ def call(Map args) {
     }
 
     stages {
-      stage("Configure build parameters") {
-        agent { label 'master' }
-        steps {
-          script {
-            sh 'env'
-            def triggers = []
-            library("tailor-meta@$tailor_meta")
-
-            // Cancel previous builds only if the build was not triggered by a PR comment. This avoids cancelling a
-            // build-and-test run when an integration test is triggered.
-            def build_causes = currentBuild.getBuildCauses(pr_comment_cause)
-            if (build_causes.isEmpty()) {
-              cancelPreviousBuilds()
-            }
-
-            // Only build master or release branches automatically, feature branches require SCM or manual trigger.
-            if (env.BRANCH_NAME == source_branch) {
-              triggers.add(upstream(upstreamProjects: "$rosdistro_job", threshold: hudson.model.Result.SUCCESS))
-            }
-
-            properties([
-              buildDiscarder(logRotator(
-                artifactDaysToKeepStr: days_to_keep.toString(), artifactNumToKeepStr: num_to_keep.toString(),
-                daysToKeepStr: days_to_keep.toString(), numToKeepStr: num_to_keep.toString()
-              )),
-              pipelineTriggers(triggers)
-            ])
-
-            // Retrieve repository information to handle github norifications
-            def parts = env.GIT_URL
-                        .replace('https://github.com/', '')
-                        .replace('.git', '')
-                        .split('/')
-            env.NOTIFICATION_ACCOUNT = parts[0]
-            env.NOTIFICATION_REPO = parts[1]
-            env.SHA = env.GIT_COMMIT
-
-            if (build_causes.isEmpty()) {
-              githubNotify(
-                credentialsId: 'tailor_github_keypass',
-                account: env.NOTIFICATION_ACCOUNT,
-                repo: env.NOTIFICATION_REPO,
-                sha: env.SHA,
-                context: 'ci/build-and-test',
-                description: 'Build and test stage running',
-                status: 'PENDING',
-                targetUrl: env.RUN_DISPLAY_URL
-              )
-            }
-          }
-        }
-      }
-
       stage("Trigger PR integration tests"){
         agent none
         when {
@@ -109,6 +56,54 @@ def call(Map args) {
                   string(name: 'sha', value: sha),
                 ]
             }
+          }
+        }
+      }
+
+      stage("Configure build parameters") {
+        agent { label 'master' }
+        when {
+          expression { !currentBuild.getBuildCauses(pr_comment_cause) }
+        }
+        steps {
+          script {
+            sh 'env'
+            def triggers = []
+            library("tailor-meta@$tailor_meta")
+            cancelPreviousBuilds()
+
+            // Only build master or release branches automatically, feature branches require SCM or manual trigger.
+            if (env.BRANCH_NAME == source_branch) {
+              triggers.add(upstream(upstreamProjects: "$rosdistro_job", threshold: hudson.model.Result.SUCCESS))
+            }
+
+            properties([
+              buildDiscarder(logRotator(
+                artifactDaysToKeepStr: days_to_keep.toString(), artifactNumToKeepStr: num_to_keep.toString(),
+                daysToKeepStr: days_to_keep.toString(), numToKeepStr: num_to_keep.toString()
+              )),
+              pipelineTriggers(triggers)
+            ])
+
+            // Retrieve repository information to handle github norifications
+            def parts = env.GIT_URL
+                        .replace('https://github.com/', '')
+                        .replace('.git', '')
+                        .split('/')
+            env.NOTIFICATION_ACCOUNT = parts[0]
+            env.NOTIFICATION_REPO = parts[1]
+            env.SHA = env.GIT_COMMIT
+
+            githubNotify(
+              credentialsId: 'tailor_github_keypass',
+              account: env.NOTIFICATION_ACCOUNT,
+              repo: env.NOTIFICATION_REPO,
+              sha: env.SHA,
+              context: 'ci/build-and-test',
+              description: 'Build and test stage running',
+              status: 'PENDING',
+              targetUrl: env.RUN_DISPLAY_URL
+            )
           }
         }
       }

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -158,6 +158,10 @@ def call(Map args) {
         }
         steps {
           script {
+            if (currentBuild.result == 'ABORTED') {
+              echo "Build was cancelled, skipping Build and test stage"
+              return
+            }
             def jobs = distributions.collectEntries { distribution ->
               [distribution, { node {
                 try {


### PR DESCRIPTION
By triggering both integration tests and build-and-test stages via the same pipeline we would have the following situation: 
- user pushes to repository and triggers build-and-test run
- before that finishes, user requests integration_tests via PR comment 
- the pipeline would cancel the previous build -> build-and-test and then start the integration tests 

This is not the behavior that we want. Thus, this PR switches the order of these stages and mantains the cancelPreviousBuilds call only for build-and-test runs. That way we would cancel consecutive build-and-run tests but we  do not cancel consecutive integration tests nor build-and-test followed by integration test. 

