### PR TITLE
Pass test image as parameter to ci_integration_tests pipeline

### DIFF
--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -54,6 +54,7 @@ def call(Map args) {
                   string(name: 'trigger_comment_body', value: comment_body),
                   booleanParam(name: 'build_custom_docker', value: true),
                   string(name: 'sha', value: sha),
+                  string(name: 'test_image', value: testImage('jammy')),
                 ]
             }
           }

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -20,7 +20,7 @@ def call(Map args) {
 
   def testImage = { distribution -> docker_registry - "https://" + ':tailor-image-test-' + distribution + '-' + release_label }
   def dependencyImage = { distribution -> docker_registry - "https://" + ':tailor-image-dep-checker-' + distribution + '-' + release_label }
-  def integration_tests_branch = 'RST-15286-remove-hardcoded-test-image'
+  def integration_tests_branch = 'main'
   def pr_comment_cause = 'com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause'
 
   pipeline {

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -20,7 +20,7 @@ def call(Map args) {
 
   def testImage = { distribution -> docker_registry - "https://" + ':tailor-image-test-' + distribution + '-' + release_label }
   def dependencyImage = { distribution -> docker_registry - "https://" + ':tailor-image-dep-checker-' + distribution + '-' + release_label }
-  def integration_tests_branch = 'main'
+  def integration_tests_branch = 'RST-15286-remove-hardcoded-test-image'
   def pr_comment_cause = 'com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause'
 
   pipeline {


### PR DESCRIPTION
When we trigger an integration test via a PR comment, we should pass the corresponding test image that the integration test pipeline should use. Currently, we hardcode it to use the Jammy version of the test image.