### PR TITLE
Add integration tests sub-stage

### DIFF
--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -232,7 +232,7 @@ def call(Map args) {
         agent none
         when {
           expression {
-            getBuildType() in [BuildType.HOTDOG, BuildType.CANDIDATE, BuildType.FEATURE]
+            getBuildType() in [BuildType.HOTDOG, BuildType.CANDIDATE]
           }
         }
         steps {

--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -118,6 +118,8 @@ def call(Map args) {
     )
   }
 
+  def integration_tests_branch = 'main'
+
   pipeline {
     agent none
 
@@ -222,6 +224,28 @@ def call(Map args) {
         steps {
           script {
             createTailorJob('tailor-meta', tailor_meta)
+          }
+        }
+      }
+
+      stage("Sub-pipeline: integration tests") {
+        agent none
+        when {
+          expression {
+            getBuildType() in [BuildType.HOTDOG, BuildType.CANDIDATE]
+          }
+        }
+        steps {
+          script {
+            node{
+              build job: "ci_integration_tests/$integration_tests_branch",
+              wait: false,
+              propagate: false,
+              parameters: [
+                string(name: 'tailor_meta', value: tailor_meta),
+                string(name: 'release_label', value: getBuildLabel()),
+              ]
+            }
           }
         }
       }

--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -118,7 +118,7 @@ def call(Map args) {
     )
   }
 
-  def integration_tests_branch = 'main'
+  def integration_tests_branch = 'RST-15413-remove-hardcoded-vars'
 
   pipeline {
     agent none
@@ -232,7 +232,7 @@ def call(Map args) {
         agent none
         when {
           expression {
-            getBuildType() in [BuildType.HOTDOG, BuildType.CANDIDATE]
+            getBuildType() in [BuildType.HOTDOG, BuildType.CANDIDATE, BuildType.FEATURE]
           }
         }
         steps {

--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -193,11 +193,11 @@ def call(Map args) {
             getBuildType() in [BuildType.FEATURE, BuildType.HOTDOG, BuildType.CANDIDATE, BuildType.FINAL]
           }
         }
-        steps {
-          script {
-            createTailorJob('tailor-distro', tailor_distro)
-          }
-        }
+        // steps {
+        //   script {
+        //     createTailorJob('tailor-distro', tailor_distro)
+        //   }
+        // }
       }
 
       stage("Sub-pipeline: bake images") {
@@ -207,11 +207,11 @@ def call(Map args) {
             getBuildType() in [BuildType.FEATURE, BuildType.HOTDOG, BuildType.CANDIDATE, BuildType.FINAL]
           }
         }
-        steps {
-          script {
-            createTailorJob('tailor-image', tailor_image)
-          }
-        }
+        // steps {
+        //   script {
+        //     createTailorJob('tailor-image', tailor_image)
+        //   }
+        // }
       }
 
       stage("Sub-pipeline: process meta") {

--- a/vars/tailorDistroPipeline.groovy
+++ b/vars/tailorDistroPipeline.groovy
@@ -118,7 +118,7 @@ def call(Map args) {
     )
   }
 
-  def integration_tests_branch = 'RST-15413-remove-hardcoded-vars'
+  def integration_tests_branch = 'main'
 
   pipeline {
     agent none
@@ -193,11 +193,11 @@ def call(Map args) {
             getBuildType() in [BuildType.FEATURE, BuildType.HOTDOG, BuildType.CANDIDATE, BuildType.FINAL]
           }
         }
-        // steps {
-        //   script {
-        //     createTailorJob('tailor-distro', tailor_distro)
-        //   }
-        // }
+        steps {
+          script {
+            createTailorJob('tailor-distro', tailor_distro)
+          }
+        }
       }
 
       stage("Sub-pipeline: bake images") {
@@ -207,11 +207,11 @@ def call(Map args) {
             getBuildType() in [BuildType.FEATURE, BuildType.HOTDOG, BuildType.CANDIDATE, BuildType.FINAL]
           }
         }
-        // steps {
-        //   script {
-        //     createTailorJob('tailor-image', tailor_image)
-        //   }
-        // }
+        steps {
+          script {
+            createTailorJob('tailor-image', tailor_image)
+          }
+        }
       }
 
       stage("Sub-pipeline: process meta") {

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -54,7 +54,7 @@ def call(Map args) {
                   string(name: 'trigger_comment_body', value: comment_body),
                   booleanParam(name: 'build_custom_docker', value: true),
                   string(name: 'sha', value: sha),
-                  string(name: 'test_image', value: testImage('jammy')),
+                  string(name: 'release_label', value: release_label),
                 ]
             }
           }

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -20,7 +20,7 @@ def call(Map args) {
 
   def testImage = { distribution -> docker_registry - "https://" + ':tailor-image-test-' + distribution + '-' + release_label }
   def dependencyImage = { distribution -> docker_registry - "https://" + ':tailor-image-dep-checker-' + distribution + '-' + release_label }
-  def integration_tests_branch = 'main'
+  def integration_tests_branch = 'RST-15413-remove-hardcoded-vars'
   def pr_comment_cause = 'com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause'
 
   pipeline {

--- a/vars/tailorTestPipeline.groovy
+++ b/vars/tailorTestPipeline.groovy
@@ -20,7 +20,7 @@ def call(Map args) {
 
   def testImage = { distribution -> docker_registry - "https://" + ':tailor-image-test-' + distribution + '-' + release_label }
   def dependencyImage = { distribution -> docker_registry - "https://" + ':tailor-image-dep-checker-' + distribution + '-' + release_label }
-  def integration_tests_branch = 'RST-15413-remove-hardcoded-vars'
+  def integration_tests_branch = 'main'
   def pr_comment_cause = 'com.adobe.jenkins.github_pr_comment_build.GitHubPullRequestCommentCause'
 
   pipeline {


### PR DESCRIPTION
- Use `release_label` parameter to send to `ci_integration_tests` pipeline instead of `test_image`
- Add a sub-stage after tailor-meta that will trigger ci_integration tests for hotdog and candidate images