### PR TITLE
Refine branch protection logic for release branches

### DIFF
--- a/tailor_meta/update_repo_settings.py
+++ b/tailor_meta/update_repo_settings.py
@@ -78,9 +78,13 @@ def update_repo_settings(rosdistro_index: pathlib.Path, recipes: Mapping[str, An
                     delete_branch_on_merge=True
                 )
 
-            # Protect branch
-            branch = gh_repo.get_branch(repository_data.get_data()["source"]["version"])
-            if deploy:
+            # Protect branch. Release branches (release/*) are covered by an org-wide
+            # ruleset that allows RST to bypass the PR requirement, so skip applying
+            # classic per-branch protection there to avoid re-introducing a branch
+            # protection rule with no bypass mechanism.
+            version = repository_data.get_data()["source"]["version"]
+            if deploy and not version.startswith('release/'):
+                branch = gh_repo.get_branch(version)
                 gh_with_retry(
                     github_client,
                     branch.edit_protection,


### PR DESCRIPTION
## Context

We recently converted release-branch (`release/**`) protection across the org from classic per-branch protection to a repository ruleset that requires PRs while allowing the RST team to bypass that requirement (needed so RST can cherry-pick fixes directly onto release branches).

## Problem

`update_repo_settings.py`'s deploy step unconditionally calls `branch.edit_protection(strict=True, required_approving_review_count=1)` on the release branch for every repo. Classic branch protection has no bypass-actor concept, so every time a new release branch is cut and this script runs, it silently re-introduces a protection rule that blocks RST again, undoing the ruleset-based bypass.

## Fix

Skip the classic `edit_protection()` call when the branch being processed matches `release/*`, since those branches are already covered by the org/repo-level ruleset. Non-release branches (e.g. default/devel branches) are unaffected and continue to get classic protection as before.